### PR TITLE
Added type state builder pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Patterns which are already implemented are marked with a [x]. Issues for example
 * [x] Factory Method
 * [x] Prototype
 * [x] Singleton (Not Polymorphic)
+* [x] [Type State Builder](src/typestatebuilder.rs) (Monomorphic Builder -> Possible to build polymorphic similar to builder though)
 
 ---
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,3 +59,7 @@ pub mod decorator_test;
 pub mod chainofresponsibility;
 #[cfg(test)]
 pub mod chainofresponsibility_test;
+
+pub mod typestatebuilder;
+#[cfg(test)]
+pub mod typestatebuilder_test;

--- a/src/typestatebuilder.rs
+++ b/src/typestatebuilder.rs
@@ -1,0 +1,115 @@
+// This is using TypeState to enhance a Builder to ensure correct usage at compile time
+// example pulled from https://github.com/jeremychone-channel/rust-builder/blob/main/src/web_states.rs
+//
+// Can do the same polymorphic behaviors as regular Builder pattern as desired
+
+use std::marker::PhantomData;
+
+// This struct represents a simple http request. This is the target this builder will create for us
+// pub properties just so I can check them in the test to quiet the warnings
+#[derive(Debug)]
+pub struct Request {
+    pub url: String,
+    pub method: String,
+    pub headers: Vec<(String, String)>,
+    pub body: Option<String>,
+}
+
+// These are states for the builder to transition between.
+// structs are required rather than an enum because these need to be different types.
+
+#[derive(Default, Clone)]
+pub struct Sealed;
+#[derive(Default, Clone)]
+pub struct NotSealed;
+
+#[derive(Default, Clone)]
+pub struct NoUrl;
+#[derive(Default, Clone)]
+pub struct Url(String);
+
+#[derive(Default, Clone)]
+pub struct NoMethod;
+#[derive(Default, Clone)]
+pub struct Method(String);
+
+// Builder
+#[derive(Debug, Default, Clone)]
+pub struct RequestBuilder<UrlState, MethodState, SealedState> {
+    url: UrlState,
+    method: MethodState,
+    headers: Vec<(String, String)>,
+    body: Option<String>,
+    marker_seal: PhantomData<SealedState>,
+}
+
+// This impl only exists on the Builder in the state with all no states.
+impl RequestBuilder<NoUrl, NoMethod, NotSealed> {
+    pub fn new() -> Self {
+        RequestBuilder::default()
+    }
+}
+
+impl<U, M> RequestBuilder<U, M, NotSealed> {
+    pub fn seal(self) -> RequestBuilder<U, M, Sealed> {
+        RequestBuilder {
+            url: self.url,
+            method: self.method,
+            headers: self.headers,
+            body: self.body,
+            marker_seal: PhantomData,
+        }
+    }
+}
+
+// Can build as long as Url and Method are defined, but whether sealed is applied or not doesn't matter
+impl<S> RequestBuilder<Url, Method, S> {
+    // could return Result or a dyn or whatever depending on if runtime checks or runtime polymorphism is needed
+    // a more typical Builder might need Result to check that url is provided for example
+    pub fn build(self) -> Request {
+        Request {
+            url: self.url.0,
+            method: self.method.0,
+            headers: self.headers,
+            body: self.body,
+        }
+    }
+}
+
+// these are available in any state other than the sealed state
+impl<U, M> RequestBuilder<U, M, NotSealed> {
+    // sets the Url state on and applies url
+    pub fn url(self, url: impl Into<String>) -> RequestBuilder<Url, M, NotSealed> {
+        RequestBuilder {
+            url: Url(url.into()),
+            method: self.method,
+            headers: self.headers,
+            body: self.body,
+            marker_seal: self.marker_seal,
+        }
+    }
+
+    // sets the method and turn on Method state
+    // probably a reasonable place to impeove by limiting method to an enum of what the supported ones are
+    pub fn method(self, method: impl Into<String>) -> RequestBuilder<U, Method, NotSealed> {
+        RequestBuilder {
+            url: self.url,
+            method: Method(method.into()),
+            headers: self.headers,
+            body: self.body,
+            marker_seal: self.marker_seal,
+        }
+    }
+
+    // sets the body
+    pub fn body(mut self, body: impl Into<String>) -> Self {
+        self.body = Some(body.into());
+        self
+    }
+
+    // appends to the header
+    pub fn header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.push((name.into(), value.into()));
+        self
+    }
+}

--- a/src/typestatebuilder_test.rs
+++ b/src/typestatebuilder_test.rs
@@ -1,0 +1,54 @@
+use crate::typestatebuilder::*;
+
+#[test]
+fn requester() {
+    // doesn't require template args because new is only defined on the <no, no, no> version
+    let req_builder = RequestBuilder::new()
+        .url("https://www.some-url.com")
+        .body("some body")
+        .method("GET")
+        .header("token name", "token value");
+
+    let req = req_builder.build();
+
+    assert_eq!(req.url, "https://www.some-url.com");
+    assert_eq!(req.body, Some("some body".into()));
+    assert_eq!(req.method, ("GET"));
+    assert_eq!(
+        req.headers,
+        vec!(("token name".into(), "token value".into()))
+    );
+
+    let _req_builder = RequestBuilder::new();
+    // fails to compile because required properties don't exist
+    // let req = _req_builder.build();
+
+    let _req_builder = RequestBuilder::new()
+        .body("some body")
+        .method("GET")
+        .header("token name", "token value");
+
+    // fails to compile because no url
+    // let req = _req_builder.build();
+
+    let _req_builder = RequestBuilder::new()
+        .url("https://www.some-url.com")
+        .body("some body")
+        .header("token name", "token value");
+
+    // fails to compile because no method
+    // let req = _req_builder.build();
+
+    let _req_builder = RequestBuilder::new()
+        .url("https://www.some-url.com")
+        .body("some body")
+        .method("GET")
+        .header("token name", "token value");
+
+    let _req_builder = _req_builder.seal();
+
+    // fails to compile because sealed
+    // let req_builder = _req_builder.url("https://www.some-url.com");
+
+    let _req = _req_builder.build();
+}


### PR DESCRIPTION
Added an example of using the type state pattern in a builder.

Possibly out of scope of the project since type state is primarily reliant on monomorphization, but there's nothing preventing it being mixed with other more dynamic polymorphic patterns to create objects in a way that doesn't need Result<> to ensure all the required properties have been set when future developers try to use the class.

Not certain on best practices for when to use it since it's just a pattern I saw recently that seemed interesting and haven't really experienced the pros/cons yet.